### PR TITLE
Compatibility enhancement and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This repository provides everything necessary to train and evaluate a single-per
 
 Requirements:
 
-- Python 3 (code has been tested on Python 3.6)
-- PyTorch (code tested with 1.0)
-- CUDA and cuDNN
-- Python packages (not exhaustive): opencv-python, tqdm, cffi, h5py, scipy (tested with 1.1.0)
+- Python 3 (code has been tested on Python 3.8.2)
+- PyTorch (code tested with 1.5)
+- CUDA and cuDNN (tested with Cuda 10)
+- Python packages (not exhaustive): opencv-python (tested with 4.2), tqdm, cffi, h5py, scipy (tested with 1.4.1), imageio
 
 Structure:
 - ```data/```: data loading and data augmentation code

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements:
 - Python 3 (code has been tested on Python 3.8.2)
 - PyTorch (code tested with 1.5)
 - CUDA and cuDNN (tested with Cuda 10)
-- Python packages (not exhaustive): opencv-python (tested with 4.2), tqdm, cffi, h5py, scipy (tested with 1.4.1), imageio
+- Python packages (not exhaustive): opencv-python (tested with 4.2), tqdm, cffi, h5py, scipy (tested with 1.4.1), pytz, imageio
 
 Structure:
 - ```data/```: data loading and data augmentation code
@@ -47,9 +47,9 @@ The option "-m n" will automatically stop training after n total iterations (if 
 
 #### Pretrained Models
 
-An 8HG pretrained model is available [here](http://www-personal.umich.edu/~cnris/original_8hg/checkpoint.pt). It should yield validation accuracy of 0.901.
+An 8HG pretrained model is available [here](http://www-personal.umich.edu/~cnris/original_8hg/checkpoint.pt). It should yield validation accuracy of 0.902.
 
-A 2HG pretrained model is available [here](http://www-personal.umich.edu/~cnris/original_2hg/checkpoint.pt). It should yield validation accuracy of 0.885.
+A 2HG pretrained model is available [here](http://www-personal.umich.edu/~cnris/original_2hg/checkpoint.pt). It should yield validation accuracy of 0.883.
 
 Models should be formatted as exp/<exp_name>/checkpoint.pt
 

--- a/data/MPII/dp.py
+++ b/data/MPII/dp.py
@@ -150,7 +150,12 @@ def init(config):
         batchnum = config['train']['{}_iters'.format(phase)]
         loader = loaders[phase].__iter__()
         for i in range(batchnum):
-            imgs, heatmaps = next(loader)
+            try:
+                imgs, heatmaps = next(loader)
+            except StopIteration:
+                # to avoid no data provided by dataloader
+                loader = loaders[phase].__iter__()
+                imgs, heatmaps = next(loader)
             yield {
                 'imgs': imgs, #cropped and augmented
                 'heatmaps': heatmaps, #based on keypoints. 0 if not in img for joint

--- a/data/MPII/ref.py
+++ b/data/MPII/ref.py
@@ -1,7 +1,7 @@
 import numpy as np
 import h5py
-from scipy.misc import imread
-import os 
+from imageio import imread
+import os
 import time
 
 def _isArrayLike(obj):

--- a/data/MPII/ref.py
+++ b/data/MPII/ref.py
@@ -90,7 +90,7 @@ def setup_val_split():
 def get_img(idx):
     imgname, __, __, __, __, __ = mpii.getAnnots(idx)
     path = os.path.join(img_dir, imgname)
-    img = imread(path, mode='RGB')
+    img = imread(path)
     return img
 
 def get_path(idx):

--- a/train.py
+++ b/train.py
@@ -12,6 +12,8 @@ import argparse
 from datetime import datetime
 from pytz import timezone
 
+import shutil
+
 def parse_command_line():
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--continue_exp', type=str, help='continue exp')

--- a/utils/group.py
+++ b/utils/group.py
@@ -22,7 +22,9 @@ class HeatmapParser:
         return det
 
     def calc(self, det):
-        det = torch.autograd.Variable(torch.Tensor(det), volatile=True)
+        with torch.no_grad():
+            det = torch.autograd.Variable(torch.Tensor(det))
+            # This is a better format for future version pytorch
 
         det = self.nms(det)
         h = det.size()[2]

--- a/utils/img.py
+++ b/utils/img.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.misc
+import cv2
 
 # =============================================================================
 # General image processing functions
@@ -59,7 +60,7 @@ def crop(img, center, scale, res, rot=0):
     old_y = max(0, ul[1]), min(len(img), br[1])
     new_img[new_y[0]:new_y[1], new_x[0]:new_x[1]] = img[old_y[0]:old_y[1], old_x[0]:old_x[1]]
 
-    return scipy.misc.imresize(new_img, res)
+    return cv2.resize(new_img, res)
 
 def inv_mat(mat):
     ans = np.linalg.pinv(np.array(mat).tolist() + [[0,0,1]])
@@ -72,5 +73,4 @@ def kpt_affine(kpt, mat):
     return np.dot( np.concatenate((kpt, kpt[:, 0:1]*0+1), axis = 1), mat.T ).reshape(shape)
 
 def resize(im, res):
-    import cv2
     return np.array([cv2.resize(im[i],res) for i in range(im.shape[0])])


### PR DESCRIPTION
1. Compatibility enhanced.
The original version could only use package "scipy" with no more than 1.2 version. Otherwise, images could not be read and resized.
While, this commit allows the latest version (1.4.1).
Also, python 3.8.2 and pytorch 1.5 under Ubuntu 20.04 has been tested to be fine.
2. Fix a bug.
The original version forgets to "import shutil" in `train.py`. This has been added.