### PR TITLE
Put batchnorm in eval mode in validation phase

### DIFF
--- a/task/pose.py
+++ b/task/pose.py
@@ -106,6 +106,13 @@ def make_network(configs):
 
         net = net.train()
 
+        # When in validation phase put batchnorm layers in eval mode
+        # to prevent running stats from getting updated.
+        if phase == 'valid':
+            for module in net.modules():
+                if isinstance(module, nn.BatchNorm2d):
+                    module.eval()
+
         if phase != 'inference':
             result = net(inputs['imgs'], **{i:inputs[i] for i in inputs if i!='imgs'})
             num_loss = len(config['train']['loss'])


### PR DESCRIPTION
- Only put batchnorm layers in eval mode when in validation phase.
   - Can't put the whole `Trainer`  in eval mode since loss calculation requires it to be in train mode.
   - Editing `Trainer`  class itself might be an overkill to fix this issue. 
- No changes in other parts of the pipeline.
- Closes #44 